### PR TITLE
Fix Kudo buttons to work with Strava React rewrite (by @ThomasMldr)

### DIFF
--- a/extension/js/main.js
+++ b/extension/js/main.js
@@ -1264,6 +1264,7 @@ function StravaEnhancementSuite($, options) {
 
       function checkCanKudo(btn) {
         var $btn = $(btn);
+        if($btn.children("svg").first().attr("data-testid") === "filled_kudos") return false; //no need to check anything further
         var content = $btn.closest(".content");
         var activityData = JSON.parse(content.attr("data-react-props"));
         if (activityData.activity) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Strava Enhancement Suite",
   "description": "Handy tools and improvements to Strava.com",
-  "version": "2.20.0",
+  "version": "2.20.1",
 
   "background": {
     "scripts": ["js/libs/browser-polyfill.js", "js/background.js"]


### PR DESCRIPTION
the simple js selector from before is gone, the arrive.js can't properly observe the data that's being loaded with react and has data-attributes that are being set after load (not even with fireOnAttributesModification apparently).
checking can_kudo in the data-react-props ensures that we check if a button needs to be clicked or not (for example not click your own kudo button which opens a popup)